### PR TITLE
Test Django 4.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{38,39}-django{32}
-    py{39,310,311}-django{40,41}
+    py{39,310,311}-django{40,41,42}
 
 [testenv]
 setenv = PYTHONPATH = {toxinidir}


### PR DESCRIPTION
Fix missing Django 4.2 reference from the default tox env